### PR TITLE
update QSEECOM mem regions

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8994-kitakami_satsuki_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8994-kitakami_satsuki_common.dtsi
@@ -342,3 +342,7 @@
 &removed_regions {
 	reg = <0 0x06A00000 0 0x9800000>;
 };
+
+&peripheral_mem {
+	reg = <0 0x0ca00000 0 0x3600000>;
+};

--- a/arch/arm/boot/dts/qcom/msm8994-kitakami_sumire_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8994-kitakami_sumire_common.dtsi
@@ -19,9 +19,9 @@
 
 &soc {
 	/delete-node/ qcom,qseecom@6500000;
-	qcom,qseecom@e700000 {
+	qcom,qseecom@e900000 {
 		compatible = "qcom,qseecom";
-		reg = <0xe700000 0x1900000>;
+		reg = <0xe900000 0x1900000>;
 		reg-names = "secapp-region";
 		qcom,disk-encrypt-pipe-pair = <2>;
 		qcom,file-encrypt-pipe-pair = <0>;
@@ -285,5 +285,9 @@
 };
 
 &removed_regions {
-	reg = <0 0x06300000 0 0x9D00000>;
+	reg = <0 0x06A00000 0 0x9800000>;
+};
+
+&peripheral_mem {
+	reg = <0 0x0ca00000 0 0x3600000>;
 };

--- a/arch/arm/boot/dts/qcom/msm8994-kitakami_suzuran_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8994-kitakami_suzuran_common.dtsi
@@ -41,9 +41,9 @@
 	};
 
 	/delete-node/ qcom,qseecom@6500000;
-	qcom,qseecom@e700000 {
+	qcom,qseecom@e900000 {
 		compatible = "qcom,qseecom";
-		reg = <0xe700000 0x1900000>;
+		reg = <0xe900000 0x1900000>;
 		reg-names = "secapp-region";
 		qcom,disk-encrypt-pipe-pair = <2>;
 		qcom,file-encrypt-pipe-pair = <0>;
@@ -293,7 +293,11 @@
 };
 
 &removed_regions {
-	reg = <0 0x06300000 0 0x9D00000>;
+	reg = <0 0x06A00000 0 0x9800000>;
+};
+
+&peripheral_mem {
+	reg = <0 0x0ca00000 0 0x3600000>;
 };
 
 &pcie1 {


### PR DESCRIPTION
diff picked from 32.1.A.1.185 to fix memory overlap

Signed-off-by: Alin Jerpelea alin.jerpelea@sonymobile.com
